### PR TITLE
Added check for ppiclf_iostep > 0.

### DIFF
--- a/source/ppiclf_solve.f
+++ b/source/ppiclf_solve.f
@@ -953,6 +953,7 @@ c----------------------------------------------------------------------
      >   call ppiclf_solve_IntegrateRK3s(iout)
 
       ! output files
+      if (ppiclf_iostep .gt.0)then
       if (mod(ppiclf_cycle,ppiclf_iostep) .eq. 0 .and. iout) then
 
          ! already wrote initial conditions
@@ -968,6 +969,7 @@ c----------------------------------------------------------------------
       ! Output diagnostics
       if (mod(ppiclf_cycle,ppiclf_iostep) .eq. 0 .and. iout) then
          call ppiclf_io_OutputDiagAll
+      endif
       endif
 
       return


### PR DESCRIPTION
This is useful when using "writeControl = runTime" since iostep is set to 0 in Nek5000. In that case, the user should make sure to set iostep manually when it is time to output data, e.g. if outfld == True then iostep = 1.